### PR TITLE
Refactor view components in Wip/framework

### DIFF
--- a/src/app/components/_services.ts
+++ b/src/app/components/_services.ts
@@ -22,4 +22,3 @@ export * from '../services/resources.service';
 // api objects
 export * from '../services/api-objects/search-response-json';
 export * from '../services/api-objects/resources-response-json';
-export * from '../services/api-objects/_subject-json';

--- a/src/app/components/view/grid-view/grid-view.component.html
+++ b/src/app/components/view/grid-view/grid-view.component.html
@@ -1,5 +1,5 @@
 <md-grid-list cols="3" gutterSize="12px">
-    <md-grid-tile *ngFor="let item of searchResponse" (click)="openResource(item.obj_id)">
+    <md-grid-tile *ngFor="let item of searchResponse?.subjects" (click)="openResource(item.obj_id)">
         <img [src]="item.preview_path" (error)="previewError($event, item.preview_path)" />
         <p>{{item.value[0]}}</p>
     </md-grid-tile>

--- a/src/app/components/view/grid-view/grid-view.component.html
+++ b/src/app/components/view/grid-view/grid-view.component.html
@@ -1,3 +1,6 @@
-<p>
-  grid-view works!
-</p>
+<md-grid-list cols="3" gutterSize="12px">
+    <md-grid-tile *ngFor="let item of searchResponse" (click)="openResource(item.obj_id)">
+        <img [src]="item.preview_path" (error)="previewError($event, item.preview_path)" />
+        <p>{{item.value[0]}}</p>
+    </md-grid-tile>
+</md-grid-list>

--- a/src/app/components/view/grid-view/grid-view.component.ts
+++ b/src/app/components/view/grid-view/grid-view.component.ts
@@ -13,7 +13,7 @@
  * */
 
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { SubjectJson } from '../../_services';
+import { SearchResponseJson } from '../../_services';
 
 @Component({
   selector: 'salsah-grid-view',
@@ -22,7 +22,7 @@ import { SubjectJson } from '../../_services';
 })
 
 export class GridViewComponent implements OnInit {
-    @Input() searchResponse: SubjectJson[];
+    @Input() searchResponse: SearchResponseJson;
     @Output() openRequest = new EventEmitter<any>();
     @Output() errorRequest = new EventEmitter<any>();
 
@@ -31,7 +31,7 @@ export class GridViewComponent implements OnInit {
     ngOnInit() {
     }
 
-    openResource(id) {
+    openResource(id: string) {
         this.openRequest.emit(id);
     }
 

--- a/src/app/components/view/grid-view/grid-view.component.ts
+++ b/src/app/components/view/grid-view/grid-view.component.ts
@@ -12,7 +12,8 @@
  * License along with SALSAH.  If not, see <http://www.gnu.org/licenses/>.
  * */
 
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { SubjectJson } from '../../_services';
 
 @Component({
   selector: 'salsah-grid-view',
@@ -21,10 +22,20 @@ import { Component, OnInit } from '@angular/core';
 })
 
 export class GridViewComponent implements OnInit {
+    @Input() searchResponse: SubjectJson[];
+    @Output() openRequest = new EventEmitter<any>();
+    @Output() errorRequest = new EventEmitter<any>();
 
     constructor() { }
 
     ngOnInit() {
     }
 
+    openResource(id) {
+        this.openRequest.emit(id);
+    }
+
+    previewError(event: Event, path: string) {
+        this.errorRequest.emit({event, path});
+    }
 }

--- a/src/app/components/view/list-view/list-view.component.html
+++ b/src/app/components/view/list-view/list-view.component.html
@@ -1,5 +1,5 @@
 <md-list>
-    <md-list-item *ngFor="let item of searchResponse" >
+    <md-list-item *ngFor="let item of searchResponse?.subjects" >
         <img md-list-avatar [src]="item.preview_path" (click)="openResource(item.obj_id)" (error)="previewError($event, item.preview_path)" />
         <p md-line>
             <button md-icon-button  class="resource-icon">

--- a/src/app/components/view/list-view/list-view.component.html
+++ b/src/app/components/view/list-view/list-view.component.html
@@ -13,7 +13,7 @@
             <span (click)="openResource(item.obj_id)">{{item.valuelabel[0]}}:
                                 <strong>{{item.value[0]}}</strong> &mdash;
                             </span>
-            <a routerLink="/resources/{{item.obj_id}}">{{item.obj_id}}</a>
+            <a (click)="openResource(item.obj_id)">{{item.obj_id}}</a>
         </p>
         <p md-line (click)="openResource(item.obj_id)" >{{item.valuelabel[1]}}: {{item.value[1]}}</p>
     </md-list-item>

--- a/src/app/components/view/list-view/list-view.component.ts
+++ b/src/app/components/view/list-view/list-view.component.ts
@@ -12,9 +12,8 @@
  * License along with SALSAH.  If not, see <http://www.gnu.org/licenses/>.
  * */
 
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { SubjectJson } from '../../_services';
-//import {EventEmitter} from "events";
 
 @Component({
   selector: 'salsah-list-view',
@@ -23,17 +22,16 @@ import { SubjectJson } from '../../_services';
 })
 
 export class ListViewComponent implements OnInit {
-
-  constructor() { }
-
     @Input() searchResponse: SubjectJson[];
     @Output() openRequest = new EventEmitter<any>();
     @Output() errorRequest = new EventEmitter<any>();
 
-    ngOnInit() {
-  }
+    constructor() { }
 
-  openResource(id){
+    ngOnInit() {
+    }
+
+    openResource(id: string) {
         this.openRequest.emit(id);
     }
 

--- a/src/app/components/view/list-view/list-view.component.ts
+++ b/src/app/components/view/list-view/list-view.component.ts
@@ -13,7 +13,7 @@
  * */
 
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { SubjectJson } from '../../_services';
+import { SearchResponseJson } from '../../_services';
 
 @Component({
   selector: 'salsah-list-view',
@@ -22,7 +22,7 @@ import { SubjectJson } from '../../_services';
 })
 
 export class ListViewComponent implements OnInit {
-    @Input() searchResponse: SubjectJson[];
+    @Input() searchResponse: SearchResponseJson;
     @Output() openRequest = new EventEmitter<any>();
     @Output() errorRequest = new EventEmitter<any>();
 

--- a/src/app/components/view/list-view/list-view.component.ts
+++ b/src/app/components/view/list-view/list-view.component.ts
@@ -35,9 +35,10 @@ export class ListViewComponent implements OnInit {
 
   openResource(id){
         this.openRequest.emit(id);
-  }
-  previewError(){
-        this.errorRequest.emit(event);
-  }
+    }
+
+    previewError(event: Event, path: string) {
+        this.errorRequest.emit({event, path});
+    }
 
 }

--- a/src/app/components/view/resource-view/resource-view.component.html
+++ b/src/app/components/view/resource-view/resource-view.component.html
@@ -5,3 +5,9 @@
 <button type="button" md-button
         (click)="dialogRef.close()">Cancel</button>
 -->
+
+<!-- preview of received response -->
+<pre>
+    Have a look at resourceResponseJSON:
+    {{resourcesResponse | json }}
+</pre>

--- a/src/app/components/view/resource-view/resource-view.component.ts
+++ b/src/app/components/view/resource-view/resource-view.component.ts
@@ -15,13 +15,11 @@ import {ResourcesResponseJson} from '../../_services';
 
 export class ResourceViewComponent implements OnInit {
 
-
     private errorMessage: string = undefined;
     public resourcesResponse: ResourcesResponseJson = new ResourcesResponseJson();
 
-    constructor(private _resourcesService: ResourcesService,
-                private _route: ActivatedRoute
-                ) {
+    constructor( private _resourcesService: ResourcesService,
+                 private _route: ActivatedRoute ) {
 
     }
 

--- a/src/app/components/view/results-view/results-view.component.html
+++ b/src/app/components/view/results-view/results-view.component.html
@@ -2,21 +2,28 @@
     <md-toolbar>
         <span>Results: {{searchResponse?.nhits}}</span>
         <span class="fill-remaining-space"><!-- This fills the remaining space of the current row --></span>
-        <md-button-toggle-group name="alignment">
-            <md-button-toggle checked="true" value="list" title="List" (click)="toggleView('list')" ><md-icon>view_headline</md-icon></md-button-toggle>
-            <md-button-toggle value="grid" title="Grid" (click)="toggleView('grid')"><md-icon>view_module</md-icon></md-button-toggle>
-            <md-button-toggle value="table" title="Table" disabled><md-icon>view_comfy</md-icon></md-button-toggle>
+        <md-button-toggle-group name="alignment" [(ngModel)]="selectedView">
+            <md-button-toggle *ngFor="let view of viewOptions" [value]=view.name [title]=view.title [disabled]="view.isDisabled">
+                <md-icon>{{view.icon}}</md-icon>
+            </md-button-toggle>
         </md-button-toggle-group>
     </md-toolbar>
 </div>
 <div class="salsah-view-results">
     <div class="error" *ngIf="errorMessage">{{errorMessage}}</div>
 
-    <div *ngIf="list" class="list-view">
+    <!-- TODO: is there a way to call the template depending on the selected View? the following does not work of course
+        <div *ngIf="searchResponse" class="{{selectedView}}-view">
+            <salsah-{{selectedView}}-view [searchResponse]="searchResponse" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-{{selectedView}}-view>
+        </div>
+        -->
+
+    <div *ngIf="selectedView=='list' && searchResponse" class="{{selectedView}}-view">
         <salsah-list-view [searchResponse]="searchResponse" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-list-view>
     </div>
 
-    <div *ngIf="grid" class="grid-view">
+    <div *ngIf="selectedView=='grid' && searchResponse" class="{{selectedView}}-view">
         <salsah-grid-view [searchResponse]="searchResponse" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-grid-view>
     </div>
+
 </div>

--- a/src/app/components/view/results-view/results-view.component.html
+++ b/src/app/components/view/results-view/results-view.component.html
@@ -13,10 +13,10 @@
     <div class="error" *ngIf="errorMessage">{{errorMessage}}</div>
 
     <div *ngIf="list" class="list-view">
-        <salsah-list-view [searchResponse]="searchResponse?.subjects" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-list-view>
+        <salsah-list-view [searchResponse]="searchResponse" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-list-view>
     </div>
 
     <div *ngIf="grid" class="grid-view">
-        <salsah-grid-view [searchResponse]="searchResponse?.subjects" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-grid-view>
+        <salsah-grid-view [searchResponse]="searchResponse" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-grid-view>
     </div>
 </div>

--- a/src/app/components/view/results-view/results-view.component.html
+++ b/src/app/components/view/results-view/results-view.component.html
@@ -17,11 +17,6 @@
     </div>
 
     <div *ngIf="grid" class="grid-view">
-        <md-grid-list cols="3" gutterSize="12px">
-            <md-grid-tile *ngFor="let item of searchResponse?.subjects" >
-                <img [src]="item.preview_path" (error)="previewError($event)" />
-                <p>{{item.value[0]}}</p>
-            </md-grid-tile>
-        </md-grid-list>
+        <salsah-grid-view [searchResponse]="searchResponse?.subjects" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-grid-view>
     </div>
 </div>

--- a/src/app/components/view/results-view/results-view.component.html
+++ b/src/app/components/view/results-view/results-view.component.html
@@ -13,7 +13,7 @@
     <div class="error" *ngIf="errorMessage">{{errorMessage}}</div>
 
     <div *ngIf="list" class="list-view">
-        <salsah-list-view [searchResponse]="searchResponse?.subjects" (openRequest)="openResource($event)"></salsah-list-view>
+        <salsah-list-view [searchResponse]="searchResponse?.subjects" (openRequest)="openResource($event)" (errorRequest)="previewError($event)"></salsah-list-view>
     </div>
 
     <div *ngIf="grid" class="grid-view">

--- a/src/app/components/view/results-view/results-view.component.ts
+++ b/src/app/components/view/results-view/results-view.component.ts
@@ -112,6 +112,8 @@ export class ResultsViewComponent implements OnInit {
     public previewError($event: {event: Event, path: string}): void {
         console.log($event.event);
         console.log($event.path);
+
+//      TODO: error preview
     }
 
     public toggleResourceSelection(): void {

--- a/src/app/components/view/results-view/results-view.component.ts
+++ b/src/app/components/view/results-view/results-view.component.ts
@@ -15,13 +15,12 @@
 import {Component, OnInit, ViewContainerRef} from '@angular/core';
 
 import { ActivatedRoute, Params, Router } from '@angular/router';
-import { JsonConvert } from 'json2typescript';
 
 import { SearchService } from '../../_services';
 import { SearchResponseJson } from '../../_services';
 
-//import { ResourceViewComponent } from '../resource-view/resource-view.component';
-//import { MdDialogRef, MdDialog, MdDialogConfig } from '@angular/material';
+// import { ResourceViewComponent } from '../resource-view/resource-view.component';
+// import { MdDialogRef, MdDialog, MdDialogConfig } from '@angular/material';
 
 @Component({
     selector: 'salsah-results-view',
@@ -34,15 +33,35 @@ export class ResultsViewComponent implements OnInit {
     private errorMessage: string = undefined;
     public searchResponse: SearchResponseJson = new SearchResponseJson();
 
-    private list: boolean = true;
-    private grid: boolean = false;
+    selectedView: string = 'list';
+    viewOptions = [
+        {
+            name: 'list',
+            title: 'List',
+            isDisabled: false,
+            icon: 'view_headline'
+        },
+        {
+            name: 'grid',
+            title: 'Grid',
+            isDisabled: false,
+            icon: 'view_module'
+        },
+        {
+            name: 'table',
+            title: 'Table',
+            isDisabled: true,
+            icon: 'view_comfy'
+        }
+    ];
 
     constructor(private _searchService: SearchService,
                 private _route: ActivatedRoute,
                 private route: ActivatedRoute,
                 private router: Router,
-                //private _dialog: MdDialog,
-                private viewContainerRef: ViewContainerRef) {
+                // private _dialog: MdDialog,
+                // private viewContainerRef: ViewContainerRef
+                ) {
     }
 
     ngOnInit() {
@@ -66,27 +85,6 @@ export class ResultsViewComponent implements OnInit {
 //        JsonConvert.debugMode = true;
 //        JsonConvert.ignorePrimitiveChecks = false; // don't allow assigning number to string etc.
 //        JsonConvert.valueCheckingMode = JsonConvert.ValueCheckingMode.DISALLOW_NULL; // never allow null
-    }
-
-
-    /**
-     *
-     * @param type
-     */
-    public toggleView(type: string): void {
-        switch (type) {
-            case 'list':
-                this.list = true;
-                this.grid = false;
-                break;
-            case 'grid':
-                this.list = false;
-                this.grid = true;
-                break;
-            default:
-                this.list = true;
-                this.grid = false;
-        }
     }
 
     public openResource(id: string): void {

--- a/src/app/components/view/results-view/results-view.component.ts
+++ b/src/app/components/view/results-view/results-view.component.ts
@@ -109,11 +109,9 @@ export class ResultsViewComponent implements OnInit {
         */
     }
 
-    public previewError(event: Event, preview_path: string): void {
-        console.log(event);
-        console.log(preview_path);
-
-
+    public previewError($event: {event: Event, path: string}): void {
+        console.log($event.event);
+        console.log($event.path);
     }
 
     public toggleResourceSelection(): void {

--- a/src/app/services/api-objects/_resinfo-json.ts
+++ b/src/app/services/api-objects/_resinfo-json.ts
@@ -12,7 +12,7 @@ export class ResinfoJson {
     public restype_label: string = undefined;
 
 //    "resclass_has_location": false,
-    @JsonProperty('stresclass_has_locationatus', Boolean)
+    @JsonProperty('resclass_has_location', Boolean)
     public resclass_has_location: boolean = undefined;
 
 //    "preview": null,
@@ -66,6 +66,4 @@ export class ResinfoJson {
 //    "restype_id": "http://www.knora.org/ontology/incunabula#book"
     @JsonProperty('restype_id', String)
     public restype_id: string = undefined;
-
-
 }

--- a/src/app/services/resources.service.ts
+++ b/src/app/services/resources.service.ts
@@ -25,12 +25,12 @@ import { ResourcesResponseJson } from './api-objects/resources-response-json';
 @Injectable()
 export class ResourcesService {
 
-    constructor(private http: Http) { }
+    constructor(private _http: Http) { }
 
 
     getData(uri: string): Observable<ResourcesResponseJson> {
         let resourceData: string = `${AppConfig.API_ENDPOINT}` + 'resources/' + uri;
-        return this.http.get(resourceData)
+        return this._http.get(resourceData)
             .map(this.extractData)
             .catch(this.handleError);
     }
@@ -44,13 +44,10 @@ export class ResourcesService {
             return Observable.throw('Data error in salsah\'s resources service.');
         }
     }
-    private handleError (error: any) {
+
+    private handleError(error: any) {
         let errMsg = (error.message) ? error.message :
             error.status ? `${error.status} - ${error.statusText}` : 'Server error';
         return Observable.throw(errMsg);
     }
-
 }
-
-
-

--- a/src/app/services/resources.service.ts
+++ b/src/app/services/resources.service.ts
@@ -37,11 +37,11 @@ export class ResourcesService {
 
     private extractData(res: Response) {
         try {
-            console.log(res.json());
+            // console.log(res.json());
             return JsonConvert.deserializeObject(res.json(), ResourcesResponseJson);
         } catch (e) {
             // console.log(e);
-            return Observable.throw('Data error in salsah\'s search service.');
+            return Observable.throw('Data error in salsah\'s resources service.');
         }
     }
     private handleError (error: any) {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -25,13 +25,13 @@ import { SearchResponseJson } from './api-objects/search-response-json';
 @Injectable()
 export class SearchService {
 
-    constructor(private http: Http) { }
+    constructor(private _http: Http) { }
 
     private searchType: string = 'fulltext';
 
     getData(searchString: string): Observable<SearchResponseJson> {
         let projectData: string = `${AppConfig.API_ENDPOINT}` + 'search/' + searchString + '?searchtype=' + this.searchType;
-        return this.http.get(projectData)
+        return this._http.get(projectData)
             .map(this.extractData)
             .catch(this.handleError);
     }
@@ -45,10 +45,10 @@ export class SearchService {
             return Observable.throw('Data error in salsah\'s search service.');
         }
     }
-    private handleError (error: any) {
+
+    private handleError(error: any) {
         let errMsg = (error.message) ? error.message :
             error.status ? `${error.status} - ${error.statusText}` : 'Server error';
         return Observable.throw(errMsg);
     }
-
 }


### PR DESCRIPTION
This PR refactors ViewComponents (list-view, grid-view and results-view):
- extends property & event binding
- calls grid-view from its own component
- improves "communication" between results-view and child views
- dynamically identifies selected view